### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/vsmind/8b231b1f-e47d-4ddd-92d6-67a086d524c2/e31971a0-52b4-4c55-a701-e28af6e1f6f5/_apis/work/boardbadge/cd819375-dc62-44c6-9a84-13137b09e66f)](https://dev.azure.com/vsmind/8b231b1f-e47d-4ddd-92d6-67a086d524c2/_boards/board/t/e31971a0-52b4-4c55-a701-e28af6e1f6f5/Microsoft.RequirementCategory)
 # wth-github-dev-ops
 
 ![WTH LOGO](./docs/wth-logo.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/vsmind/8b231b1f-e47d-4ddd-92d6-67a086d524c2/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.